### PR TITLE
Update ORM for Fall 2023 edition.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Introduction
 
-These scripts are based on those developed at altay-oz/load_patstat. 
+These scripts are based on those developed at altay-oz/load_patstat.
 
 The bulk downloads provided by EPO are served as batches of zip files. This
 script assumes you have already downloaded and extracted these zip files, and
@@ -17,6 +17,7 @@ on localhost.
 This repository contains scripts tested for the following PATSTAT versions (see the releases in this repository for corresponding versions):
 * Spring 2022*
 * Fall 2022*
+* Fall 2023
 
 Releases marked with an asterisk have one or more point releases available for bugfixes. Always use the latest release for your version of PATSTAT.
 

--- a/create_patstat_tables.sql
+++ b/create_patstat_tables.sql
@@ -5,6 +5,7 @@ CREATE TABLE tls201_appln (
     appln_kind char(2) DEFAULT '' NOT NULL,
     appln_filing_date date DEFAULT '9999-12-31' NOT NULL,
     appln_filing_year smallint DEFAULT '9999' NOT NULL,
+    appln_nr_epodoc varchar(20) DEFAULT '' NOT NULL,
     appln_nr_original varchar(100) DEFAULT '' NOT NULL,
     ipr_type char(2) DEFAULT '' NOT NULL,
     receiving_office char(2) DEFAULT '' NOT NULL,
@@ -277,7 +278,7 @@ CREATE TABLE tls231_inpadoc_legal_event (
 
 CREATE TABLE tls801_country (
     ctry_code char(2) DEFAULT '' NOT NULL,
-    iso_alph3 varchar(3) DEFAULT '' NOT NULL,
+    iso_alpha3 varchar(3) DEFAULT '' NOT NULL,
     st3_name varchar(100) DEFAULT '' NOT NULL,
     organisation_flag char(1) DEFAULT '' NOT NULL,
     continent varchar(25) DEFAULT '' NOT NULL,


### PR DESCRIPTION
Based on version 5.22 from 31.10.2023, 2023 Autumn Edition.

EPO reintroduced `appln_nr_epodoc` in `tls201_appln`.
![Screenshot from 2024-01-28 14-14-08](https://github.com/Ianvdl/patstat-to-postgresql/assets/5410394/38820717-ba46-4bd5-b694-1e31395c22e4)

They also changed `iso_alph3` to `iso_alpha3` in `tls801_country`. There is no mention about this in the documentation.